### PR TITLE
Export functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,34 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
 
-    <groupId>edu.stanford.protege</groupId>
-    <artifactId>owl-diff</artifactId>
-    <version>6.0.3-SNAPSHOT</version>
-    <packaging>bundle</packaging>
-    
-    <name>OWL Difference</name>
-    <description>Plug-in for the Protege Desktop ontology editor for comparing two OWL ontologies.</description>
-    <licenses>
-        <license>
-            <name>GNU Lesser General Public License</name>
-            <url>http://www.gnu.org/copyleft/lesser.html</url>
-        </license>
-    </licenses>
+	<groupId>edu.stanford.protege</groupId>
+	<artifactId>owl-diff</artifactId>
+	<version>6.0.3-SNAPSHOT</version>
+	<packaging>bundle</packaging>
 
-    <developers>
-        <developer>
-            <name>Timothy Redmond</name>
-            <email>tredmond@stanford.edu</email>
-        </developer>
-    </developers>
-    
+	<name>OWL Difference</name>
+	<description>Plug-in for the Protege Desktop ontology editor for comparing two OWL ontologies.</description>
+	<licenses>
+		<license>
+			<name>GNU Lesser General Public License</name>
+			<url>http://www.gnu.org/copyleft/lesser.html</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>Timothy Redmond</name>
+			<email>tredmond@stanford.edu</email>
+		</developer>
+	</developers>
+
 	<mailingLists>
 		<mailingList>
 			<name>protege-user</name>
@@ -41,125 +42,135 @@
 			</otherArchives>
 		</mailingList>
 	</mailingLists>
-	    
-    <scm>
-        <connection>scm:git:git@github.com:protegeproject/owl-diff.git</connection>
-        <developerConnection>scm:git:git@github.com:protegeproject/owl-diff.git</developerConnection>
-        <url>https://github.com/protegeproject/owl-diff</url>
-      <tag>HEAD</tag>
-  </scm>
-    
+
+	<scm>
+		<connection>scm:git:git@github.com:protegeproject/owl-diff.git</connection>
+		<developerConnection>scm:git:git@github.com:protegeproject/owl-diff.git</developerConnection>
+		<url>https://github.com/protegeproject/owl-diff</url>
+		<tag>HEAD</tag>
+	</scm>
+
 	<issueManagement>
 		<system>GitHub</system>
 		<url>https://github.com/protegeproject/owl-diff/issues</url>
 	</issueManagement>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <protege.version>5.0.0-beta-19</protege.version>
-    </properties>
-	
-    <dependencies>
-        <dependency>
-            <groupId>edu.stanford.protege</groupId>
-            <artifactId>protege-common</artifactId>
-            <version>${protege.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>edu.stanford.protege</groupId>
-            <artifactId>protege-editor-core</artifactId>
-            <version>${protege.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>edu.stanford.protege</groupId>
-            <artifactId>protege-editor-owl</artifactId>
-            <version>${protege.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>edu.stanford.protege</groupId>
-            <artifactId>owl-diff-engine</artifactId>
-            <version>3.0.0</version>
-        </dependency>
-    </dependencies>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<protege.version>5.0.0-beta-19</protege.version>
+	</properties>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.3</version>
-              <configuration>
-                <source>1.8</source>
-                <target>1.8</target>
-              </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.0.1</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-Activator>org.protege.editor.owl.diff.DifferenceActivator</Bundle-Activator>
-                        <Bundle-SymbolicName>org.protege.editor.owl.diff;singleton:=true</Bundle-SymbolicName>
-                        <Bundle-Vendor>The Protege Development Team</Bundle-Vendor>
-                        <Embed-Dependency>owl-diff-engine</Embed-Dependency>
-                        <Import-Package>
-                            org.protege.editor.core.*;version="5.0.0",
-                            org.protege.editor.owl.*;version="5.0.0",
-                            *
-                        </Import-Package>
-                        <Include-Resource>{maven-resources}</Include-Resource>
-                        <Private-Package>org.protege.editor.owl.diff.*</Private-Package>
-                    </instructions>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.9.4</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
+	<dependencies>
+		<dependency>
+			<groupId>edu.stanford.protege</groupId>
+			<artifactId>protege-common</artifactId>
+			<version>${protege.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>edu.stanford.protege</groupId>
+			<artifactId>protege-editor-core</artifactId>
+			<version>${protege.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>edu.stanford.protege</groupId>
+			<artifactId>protege-editor-owl</artifactId>
+			<version>${protege.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>edu.stanford.protege</groupId>
+			<artifactId>owl-diff-engine</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.2</version>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.4</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.10.3</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>3.0.1</version>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Bundle-Activator>org.protege.editor.owl.diff.DifferenceActivator</Bundle-Activator>
+						<Bundle-SymbolicName>org.protege.editor.owl.diff;singleton:=true</Bundle-SymbolicName>
+						<Bundle-Vendor>The Protege Development Team</Bundle-Vendor>
+						<Embed-Dependency>gson, owl-diff-engine</Embed-Dependency>
+
+
+						<Import-Package>
+							org.protege.editor.core.*;version="5.0.0",
+							org.protege.editor.owl.*;version="5.0.0",
+							*
+						</Import-Package>
+
+						<Include-Resource>{maven-resources}</Include-Resource>
+						<Private-Package>org.protege.editor.owl.diff.*</Private-Package>
+					</instructions>
+				</configuration>
+				<executions>
+					<execution>
+						<id>bundle-manifest</id>
+						<phase>install</phase>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.3</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven.scm</groupId>
+						<artifactId>maven-scm-provider-gitexe</artifactId>
+						<version>1.9.4</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
             <artifactId>owl-diff-engine</artifactId>
             <version>3.0.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
@@ -12,7 +12,7 @@
     <artifactId>owl-diff</artifactId>
     <version>6.0.3-SNAPSHOT</version>
     <packaging>bundle</packaging>
-
+    
     <name>OWL Difference</name>
     <description>Plug-in for the Protege Desktop ontology editor for comparing two OWL ontologies.</description>
     <licenses>
@@ -28,37 +28,37 @@
             <email>tredmond@stanford.edu</email>
         </developer>
     </developers>
-
-    <mailingLists>
-        <mailingList>
-            <name>protege-user</name>
-            <subscribe>https://mailman.stanford.edu/mailman/listinfo/protege-user</subscribe>
-            <unsubscribe>https://mailman.stanford.edu/mailman/listinfo/protege-user</unsubscribe>
-            <post>protege-user@lists.stanford.edu</post>
-            <archive>http://protege-project.136.n4.nabble.com/</archive>
-            <otherArchives>
-                <otherArchive>https://mailman.stanford.edu/pipermail/protege-user/</otherArchive>
-            </otherArchives>
-        </mailingList>
-    </mailingLists>
-
+    
+	<mailingLists>
+		<mailingList>
+			<name>protege-user</name>
+			<subscribe>https://mailman.stanford.edu/mailman/listinfo/protege-user</subscribe>
+			<unsubscribe>https://mailman.stanford.edu/mailman/listinfo/protege-user</unsubscribe>
+			<post>protege-user@lists.stanford.edu</post>
+			<archive>http://protege-project.136.n4.nabble.com/</archive>
+			<otherArchives>
+				<otherArchive>https://mailman.stanford.edu/pipermail/protege-user/</otherArchive>
+			</otherArchives>
+		</mailingList>
+	</mailingLists>
+	    
     <scm>
         <connection>scm:git:git@github.com:protegeproject/owl-diff.git</connection>
         <developerConnection>scm:git:git@github.com:protegeproject/owl-diff.git</developerConnection>
         <url>https://github.com/protegeproject/owl-diff</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/protegeproject/owl-diff/issues</url>
-    </issueManagement>
+      <tag>HEAD</tag>
+  </scm>
+    
+	<issueManagement>
+		<system>GitHub</system>
+		<url>https://github.com/protegeproject/owl-diff/issues</url>
+	</issueManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protege.version>5.0.0-beta-19</protege.version>
     </properties>
-
+	
     <dependencies>
         <dependency>
             <groupId>edu.stanford.protege</groupId>
@@ -91,13 +91,13 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.3</version>
+              <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+              </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -136,14 +136,11 @@
                         <Bundle-SymbolicName>org.protege.editor.owl.diff;singleton:=true</Bundle-SymbolicName>
                         <Bundle-Vendor>The Protege Development Team</Bundle-Vendor>
                         <Embed-Dependency>gson, owl-diff-engine</Embed-Dependency>
-
-
                         <Import-Package>
                             org.protege.editor.core.*;version="5.0.0",
                             org.protege.editor.owl.*;version="5.0.0",
                             *
                         </Import-Package>
-
                         <Include-Resource>{maven-resources}</Include-Resource>
                         <Private-Package>org.protege.editor.owl.diff.*</Private-Package>
                     </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>edu.stanford.protege</groupId>
     <artifactId>owl-diff</artifactId>
-    <version>6.0.3-SNAPSHOT</version>
+    <version>6.1.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     
     <name>OWL Difference</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -12,7 +13,7 @@
     <artifactId>owl-diff</artifactId>
     <version>6.0.3-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    
+
     <name>OWL Difference</name>
     <description>Plug-in for the Protege Desktop ontology editor for comparing two OWL ontologies.</description>
     <licenses>
@@ -28,37 +29,37 @@
             <email>tredmond@stanford.edu</email>
         </developer>
     </developers>
-    
-	<mailingLists>
-		<mailingList>
-			<name>protege-user</name>
-			<subscribe>https://mailman.stanford.edu/mailman/listinfo/protege-user</subscribe>
-			<unsubscribe>https://mailman.stanford.edu/mailman/listinfo/protege-user</unsubscribe>
-			<post>protege-user@lists.stanford.edu</post>
-			<archive>http://protege-project.136.n4.nabble.com/</archive>
-			<otherArchives>
-				<otherArchive>https://mailman.stanford.edu/pipermail/protege-user/</otherArchive>
-			</otherArchives>
-		</mailingList>
-	</mailingLists>
-	    
+
+    <mailingLists>
+        <mailingList>
+            <name>protege-user</name>
+            <subscribe>https://mailman.stanford.edu/mailman/listinfo/protege-user</subscribe>
+            <unsubscribe>https://mailman.stanford.edu/mailman/listinfo/protege-user</unsubscribe>
+            <post>protege-user@lists.stanford.edu</post>
+            <archive>http://protege-project.136.n4.nabble.com/</archive>
+            <otherArchives>
+                <otherArchive>https://mailman.stanford.edu/pipermail/protege-user/</otherArchive>
+            </otherArchives>
+        </mailingList>
+    </mailingLists>
+
     <scm>
         <connection>scm:git:git@github.com:protegeproject/owl-diff.git</connection>
         <developerConnection>scm:git:git@github.com:protegeproject/owl-diff.git</developerConnection>
         <url>https://github.com/protegeproject/owl-diff</url>
-      <tag>HEAD</tag>
-  </scm>
-    
-	<issueManagement>
-		<system>GitHub</system>
-		<url>https://github.com/protegeproject/owl-diff/issues</url>
-	</issueManagement>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/protegeproject/owl-diff/issues</url>
+    </issueManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protege.version>5.0.0-beta-19</protege.version>
     </properties>
-	
+
     <dependencies>
         <dependency>
             <groupId>edu.stanford.protege</groupId>
@@ -80,18 +81,25 @@
             <artifactId>owl-diff-engine</artifactId>
             <version>3.0.0</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.2</version>
+        </dependency>
+
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.3</version>
-              <configuration>
-                <source>1.8</source>
-                <target>1.8</target>
-              </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -129,12 +137,15 @@
                         <Bundle-Activator>org.protege.editor.owl.diff.DifferenceActivator</Bundle-Activator>
                         <Bundle-SymbolicName>org.protege.editor.owl.diff;singleton:=true</Bundle-SymbolicName>
                         <Bundle-Vendor>The Protege Development Team</Bundle-Vendor>
-                        <Embed-Dependency>owl-diff-engine</Embed-Dependency>
+                        <Embed-Dependency>gson, owl-diff-engine</Embed-Dependency>
+
+
                         <Import-Package>
                             org.protege.editor.core.*;version="5.0.0",
                             org.protege.editor.owl.*;version="5.0.0",
                             *
                         </Import-Package>
+
                         <Include-Resource>{maven-resources}</Include-Resource>
                         <Private-Package>org.protege.editor.owl.diff.*</Private-Package>
                     </instructions>

--- a/src/main/java/org/protege/editor/owl/diff/ui/Finder.java
+++ b/src/main/java/org/protege/editor/owl/diff/ui/Finder.java
@@ -33,15 +33,12 @@ public class Finder extends JPanel {
 	public Finder(DifferenceManager differenceManager) {
 		setLayout(new FlowLayout());
 		this.differenceManager = differenceManager;
-
-		// Export functionality
 		final JButton exportButton = new JButton("Export Differences");
 		exportButton.addActionListener(new ChangeExporter(differenceManager, this));
 		add(exportButton);
-
 		findButton = new JButton("Find");
 		findButton.addActionListener(new ActionListener() {
-
+			
 			public void actionPerformed(ActionEvent e) {
 				doFind();
 			}
@@ -65,11 +62,10 @@ public class Finder extends JPanel {
 		String toMatch = ".*" + text.getText() + ".*";
 		List<EntityBasedDiff> diffs = new ArrayList<EntityBasedDiff>();
 		for (EntityBasedDiff diff : changes.getEntityBasedDiffs()) {
-			if (diff.getSourceEntity() != null
-					&& renderer.renderSourceObject(diff.getSourceEntity()).matches(toMatch)) {
+			if (diff.getSourceEntity() != null && renderer.renderSourceObject(diff.getSourceEntity()).matches(toMatch)) {
 				diffs.add(diff);
-			} else if (diff.getTargetEntity() != null
-					&& renderer.renderTargetObject(diff.getTargetEntity()).matches(toMatch)) {
+			}
+			else if (diff.getTargetEntity() != null && renderer.renderTargetObject(diff.getTargetEntity()).matches(toMatch)) {
 				diffs.add(diff);
 			}
 		}

--- a/src/main/java/org/protege/editor/owl/diff/ui/Finder.java
+++ b/src/main/java/org/protege/editor/owl/diff/ui/Finder.java
@@ -29,7 +29,7 @@ public class Finder extends JPanel {
 			setEnabled(differenceManager.isReady());
 		}
 	};
-
+	
 	public Finder(DifferenceManager differenceManager) {
 		setLayout(new FlowLayout());
 		this.differenceManager = differenceManager;
@@ -51,16 +51,14 @@ public class Finder extends JPanel {
 		text.setPreferredSize(new JTextField("DNA topoisomerase type 1 activity").getPreferredSize());
 		add(text);
 		setEnabled(differenceManager.isReady());
-
-
 	}
-
+	
 	public void setEnabled(boolean enabled) {
 		super.setEnabled(enabled);
 		text.setEnabled(enabled);
 		findButton.setEnabled(enabled);
 	}
-
+	
 	private void doFind() {
 		Changes changes = differenceManager.getEngine().getChanges();
 		RenderingService renderer = RenderingService.get(differenceManager.getEngine());
@@ -84,7 +82,7 @@ public class Finder extends JPanel {
 		dialog.pack();
 		dialog.setVisible(true);
 	}
-
+	
 	private JList createSwingList(List<EntityBasedDiff> diffs) {
 		final JList swingList = new JList();
 		DefaultListModel model = new DefaultListModel();
@@ -107,11 +105,11 @@ public class Finder extends JPanel {
 		}
 		return swingList;
 	}
-
+	
 	public void dispose() {
 		differenceManager.removeDifferenceListener(listener);
 		differenceManager = null;
 		text = null;
 	}
-
+	
 }

--- a/src/main/java/org/protege/editor/owl/diff/ui/Finder.java
+++ b/src/main/java/org/protege/editor/owl/diff/ui/Finder.java
@@ -4,6 +4,7 @@ import org.protege.editor.owl.diff.model.DifferenceEvent;
 import org.protege.editor.owl.diff.model.DifferenceListener;
 import org.protege.editor.owl.diff.model.DifferenceManager;
 import org.protege.editor.owl.diff.model.EntityBasedDiffComparator;
+import org.protege.editor.owl.diff.ui.changeExporter.ChangeExporter;
 import org.protege.editor.owl.diff.ui.render.EntityBasedDiffRenderer;
 import org.protege.owl.diff.present.Changes;
 import org.protege.owl.diff.present.EntityBasedDiff;
@@ -28,13 +29,19 @@ public class Finder extends JPanel {
 			setEnabled(differenceManager.isReady());
 		}
 	};
-	
+
 	public Finder(DifferenceManager differenceManager) {
 		setLayout(new FlowLayout());
 		this.differenceManager = differenceManager;
+
+		// Export functionality
+		final JButton exportButton = new JButton("Export Differences");
+		exportButton.addActionListener(new ChangeExporter(differenceManager, this));
+		add(exportButton);
+
 		findButton = new JButton("Find");
 		findButton.addActionListener(new ActionListener() {
-			
+
 			public void actionPerformed(ActionEvent e) {
 				doFind();
 			}
@@ -44,24 +51,27 @@ public class Finder extends JPanel {
 		text.setPreferredSize(new JTextField("DNA topoisomerase type 1 activity").getPreferredSize());
 		add(text);
 		setEnabled(differenceManager.isReady());
+
+
 	}
-	
+
 	public void setEnabled(boolean enabled) {
 		super.setEnabled(enabled);
 		text.setEnabled(enabled);
 		findButton.setEnabled(enabled);
 	}
-	
+
 	private void doFind() {
 		Changes changes = differenceManager.getEngine().getChanges();
 		RenderingService renderer = RenderingService.get(differenceManager.getEngine());
 		String toMatch = ".*" + text.getText() + ".*";
 		List<EntityBasedDiff> diffs = new ArrayList<EntityBasedDiff>();
 		for (EntityBasedDiff diff : changes.getEntityBasedDiffs()) {
-			if (diff.getSourceEntity() != null && renderer.renderSourceObject(diff.getSourceEntity()).matches(toMatch)) {
+			if (diff.getSourceEntity() != null
+					&& renderer.renderSourceObject(diff.getSourceEntity()).matches(toMatch)) {
 				diffs.add(diff);
-			}
-			else if (diff.getTargetEntity() != null && renderer.renderTargetObject(diff.getTargetEntity()).matches(toMatch)) {
+			} else if (diff.getTargetEntity() != null
+					&& renderer.renderTargetObject(diff.getTargetEntity()).matches(toMatch)) {
 				diffs.add(diff);
 			}
 		}
@@ -74,7 +84,7 @@ public class Finder extends JPanel {
 		dialog.pack();
 		dialog.setVisible(true);
 	}
-	
+
 	private JList createSwingList(List<EntityBasedDiff> diffs) {
 		final JList swingList = new JList();
 		DefaultListModel model = new DefaultListModel();
@@ -97,11 +107,11 @@ public class Finder extends JPanel {
 		}
 		return swingList;
 	}
-	
+
 	public void dispose() {
 		differenceManager.removeDifferenceListener(listener);
 		differenceManager = null;
 		text = null;
 	}
-	
+
 }

--- a/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/ChangeExporter.java
+++ b/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/ChangeExporter.java
@@ -1,0 +1,111 @@
+package org.protege.editor.owl.diff.ui.changeExporter;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.Writer;
+
+import javax.swing.JFileChooser;
+
+import org.protege.editor.owl.diff.model.DifferenceManager;
+import org.protege.owl.diff.present.Changes;
+import org.protege.owl.diff.present.EntityBasedDiff;
+import org.protege.owl.diff.present.MatchedAxiom;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ChangeExporter implements ActionListener {
+	private DifferenceManager diffManager;
+	public static final Logger LOGGER = LoggerFactory.getLogger(ChangeExporter.class.getName());
+	private Component parent;
+
+	public ChangeExporter(DifferenceManager dm, Component parent) {
+		diffManager = dm;
+		this.parent = parent;
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent e) {
+
+		Changes changes = diffManager.getEngine().getChanges();
+
+		// DEBUG CHANGES
+
+		for (EntityBasedDiff diff : changes.getEntityBasedDiffs()) {
+			String sourceStr = diff.getSourceEntity() == null ? "null" : diff.getSourceEntity().getIRI().toString();
+			String targeStr = diff.getTargetEntity() == null ? "null" : diff.getTargetEntity().getIRI().toString();
+			LOGGER.info(diff.getDiffTypeDescription() + " " + sourceStr + " " + targeStr);
+			for (MatchedAxiom axiom : diff.getAxiomMatches()) {
+				String sourceStrAx;
+				OWLAxiom sourceAx = axiom.getSourceAxiom();
+				if (sourceAx != null) {
+					sourceStrAx = sourceAx.toString();
+				} else {
+					sourceStrAx = "null";
+				}
+				String targetStrAx;
+				OWLAxiom targetAx = axiom.getTargetAxiom();
+				if (targetAx != null) {
+					targetStrAx = targetAx.toString();
+				} else {
+					targetStrAx = "null";
+				}
+				LOGGER.info(axiom.getDescription() + " " + sourceStrAx + " " + targetStrAx);
+			}
+		}
+
+		// END DEBUG CHANGES
+
+		// select file
+
+		JFileChooser chooser = new JFileChooser();
+		if (chooser.showSaveDialog(parent) == JFileChooser.APPROVE_OPTION) {
+			File file = chooser.getSelectedFile();
+
+			try {
+				file.createNewFile();
+				OutputStream out = new FileOutputStream(file);
+				
+				PrintStream outStream = new PrintStream(out); 
+				for (EntityBasedDiff diff: changes.getEntityBasedDiffs()) {
+					String sourceStr = diff.getSourceEntity() == null ? "null" : diff.getSourceEntity().getIRI().toString();
+					String targeStr = diff.getTargetEntity() == null ? "null" : diff.getTargetEntity().getIRI().toString();
+					outStream.println(diff.getDiffTypeDescription() + " " + sourceStr + " " + targeStr);
+					for (MatchedAxiom axiom : diff.getAxiomMatches()) {
+						String sourceStrAx;
+						OWLAxiom sourceAx = axiom.getSourceAxiom();
+						if (sourceAx != null) {
+							sourceStrAx = sourceAx.toString();
+						} else {
+							sourceStrAx = "null";
+						}
+						String targetStrAx;
+						OWLAxiom targetAx = axiom.getTargetAxiom();
+						if (targetAx != null) {
+							targetStrAx = targetAx.toString();
+						} else {
+							targetStrAx = "null";
+						}
+						outStream.println("# "+axiom.getDescription() + " " + sourceStrAx + " " + targetStrAx);
+					}
+				}
+				outStream.close();
+				
+				
+			} catch (IOException e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+			}
+		}
+
+	}
+
+}

--- a/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/ChangeExporter.java
+++ b/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/ChangeExporter.java
@@ -3,24 +3,21 @@ package org.protege.editor.owl.diff.ui.changeExporter;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintStream;
-import java.io.Writer;
-
 import javax.swing.JFileChooser;
-
+import javax.swing.JOptionPane;
 import org.protege.editor.owl.diff.model.DifferenceManager;
 import org.protege.owl.diff.present.Changes;
 import org.protege.owl.diff.present.EntityBasedDiff;
-import org.protege.owl.diff.present.MatchedAxiom;
-import org.semanticweb.owlapi.model.OWLAxiom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class ChangeExporter implements ActionListener {
 	private DifferenceManager diffManager;
@@ -34,75 +31,26 @@ public class ChangeExporter implements ActionListener {
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-
 		Changes changes = diffManager.getEngine().getChanges();
-
-		// DEBUG CHANGES
-
-		for (EntityBasedDiff diff : changes.getEntityBasedDiffs()) {
-			String sourceStr = diff.getSourceEntity() == null ? "null" : diff.getSourceEntity().getIRI().toString();
-			String targeStr = diff.getTargetEntity() == null ? "null" : diff.getTargetEntity().getIRI().toString();
-			LOGGER.info(diff.getDiffTypeDescription() + " " + sourceStr + " " + targeStr);
-			for (MatchedAxiom axiom : diff.getAxiomMatches()) {
-				String sourceStrAx;
-				OWLAxiom sourceAx = axiom.getSourceAxiom();
-				if (sourceAx != null) {
-					sourceStrAx = sourceAx.toString();
-				} else {
-					sourceStrAx = "null";
-				}
-				String targetStrAx;
-				OWLAxiom targetAx = axiom.getTargetAxiom();
-				if (targetAx != null) {
-					targetStrAx = targetAx.toString();
-				} else {
-					targetStrAx = "null";
-				}
-				LOGGER.info(axiom.getDescription() + " " + sourceStrAx + " " + targetStrAx);
-			}
-		}
-
-		// END DEBUG CHANGES
-
 		// select file
-
 		JFileChooser chooser = new JFileChooser();
 		if (chooser.showSaveDialog(parent) == JFileChooser.APPROVE_OPTION) {
 			File file = chooser.getSelectedFile();
-
 			try {
+				// write output to file
 				file.createNewFile();
 				OutputStream out = new FileOutputStream(file);
-				
-				PrintStream outStream = new PrintStream(out); 
-				for (EntityBasedDiff diff: changes.getEntityBasedDiffs()) {
-					String sourceStr = diff.getSourceEntity() == null ? "null" : diff.getSourceEntity().getIRI().toString();
-					String targeStr = diff.getTargetEntity() == null ? "null" : diff.getTargetEntity().getIRI().toString();
-					outStream.println(diff.getDiffTypeDescription() + " " + sourceStr + " " + targeStr);
-					for (MatchedAxiom axiom : diff.getAxiomMatches()) {
-						String sourceStrAx;
-						OWLAxiom sourceAx = axiom.getSourceAxiom();
-						if (sourceAx != null) {
-							sourceStrAx = sourceAx.toString();
-						} else {
-							sourceStrAx = "null";
-						}
-						String targetStrAx;
-						OWLAxiom targetAx = axiom.getTargetAxiom();
-						if (targetAx != null) {
-							targetStrAx = targetAx.toString();
-						} else {
-							targetStrAx = "null";
-						}
-						outStream.println("# "+axiom.getDescription() + " " + sourceStrAx + " " + targetStrAx);
-					}
-				}
+
+				PrintStream outStream = new PrintStream(out);
+				Gson gson = new GsonBuilder().setPrettyPrinting()
+						.registerTypeAdapter(EntityBasedDiff.class, new EntityBasedDiffJSonSerializer()).create();
+				String jsonRep = gson.toJson(changes.getEntityBasedDiffs());
+				outStream.print(jsonRep);
 				outStream.close();
-				
-				
 			} catch (IOException e1) {
-				// TODO Auto-generated catch block
-				e1.printStackTrace();
+				// error message
+				JOptionPane.showMessageDialog(parent,
+						"Something went wrong saving the file. Error description:" + e1.getMessage());
 			}
 		}
 

--- a/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/ChangeExporter.java
+++ b/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/ChangeExporter.java
@@ -44,9 +44,15 @@ public class ChangeExporter implements ActionListener {
 				PrintStream outStream = new PrintStream(out);
 				Gson gson = new GsonBuilder().setPrettyPrinting()
 						.registerTypeAdapter(EntityBasedDiff.class, new EntityBasedDiffJSonSerializer()).create();
-				String jsonRep = gson.toJson(changes.getEntityBasedDiffs());
-				outStream.print(jsonRep);
+				outStream.println("[");
+				for (EntityBasedDiff diff:changes.getEntityBasedDiffs()) {
+					String jsonRep = gson.toJson(diff);
+					outStream.println(jsonRep + ",");
+				}
+				outStream.println("]");
+				
 				outStream.close();
+				JOptionPane.showMessageDialog(parent, "Saved Differences to "+file.getPath());
 			} catch (IOException e1) {
 				// error message
 				JOptionPane.showMessageDialog(parent,

--- a/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/ChangeExporter.java
+++ b/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/ChangeExporter.java
@@ -45,9 +45,16 @@ public class ChangeExporter implements ActionListener {
 				Gson gson = new GsonBuilder().setPrettyPrinting()
 						.registerTypeAdapter(EntityBasedDiff.class, new EntityBasedDiffJSonSerializer()).create();
 				outStream.println("[");
+				Boolean first = true;
 				for (EntityBasedDiff diff:changes.getEntityBasedDiffs()) {
 					String jsonRep = gson.toJson(diff);
-					outStream.println(jsonRep + ",");
+					if (first) {
+						first = false;
+					} else {
+						outStream.println(",");
+					}
+					
+					outStream.print(jsonRep);
 				}
 				outStream.println("]");
 				

--- a/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/EntityBasedDiffJSonSerializer.java
+++ b/src/main/java/org/protege/editor/owl/diff/ui/changeExporter/EntityBasedDiffJSonSerializer.java
@@ -1,0 +1,55 @@
+package org.protege.editor.owl.diff.ui.changeExporter;
+
+import java.lang.reflect.Type;
+
+import org.protege.owl.diff.present.EntityBasedDiff;
+import org.protege.owl.diff.present.MatchedAxiom;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class EntityBasedDiffJSonSerializer implements JsonSerializer<EntityBasedDiff> {
+	public static String CHANGETYPE = "changeType";
+	public static String SOURCE = "source";
+	public static String TARGET = "target";
+	public static String AXIOM_MATCHES = "axiomMatches";
+	public static String MATCH_DESCRIPTION = "description";
+
+	@Override
+	public JsonElement serialize(EntityBasedDiff arg0, Type arg1, JsonSerializationContext arg2) {
+		JsonObject result = new JsonObject();
+		result.add(CHANGETYPE, new JsonPrimitive(arg0.getDiffTypeDescription()));
+
+		if (arg0.getSourceEntity() != null) {
+			result.add(SOURCE, new JsonPrimitive(arg0.getSourceEntity().getIRI().toString()));
+		}
+
+		if (arg0.getTargetEntity() != null) {
+			result.add(TARGET, new JsonPrimitive(arg0.getTargetEntity().getIRI().toString()));
+		}
+
+		if (!arg0.getAxiomMatches().isEmpty()) {
+			JsonArray arr = new JsonArray();
+			for (MatchedAxiom ax : arg0.getAxiomMatches()) {
+				JsonObject match = new JsonObject();
+				match.add(MATCH_DESCRIPTION, new JsonPrimitive(ax.getDescription().toString()));
+				if (ax.getSourceAxiom() != null) {
+					match.add(SOURCE, new JsonPrimitive(ax.getSourceAxiom().toString()));
+				}
+				if (ax.getTargetAxiom() != null) {
+					match.add(TARGET, new JsonPrimitive(ax.getTargetAxiom().toString()));
+				}
+				arr.add(match);
+			}
+
+			result.add(AXIOM_MATCHES, arr);
+
+		}
+		return result;
+	}
+
+}


### PR DESCRIPTION
In a project i am working on, I needed to export the changes from owl-diff for another tool. For this project, I extended the owl-diff GUI with an export button. The button supports selecting a JSON-file to export the differences in a format that closely resmbles the structure of `org.protege.owl.diff.present.EntityBasedDiff`.

I thought this small extension could be useful to others working with changing ontologies, so let me hear what you think.